### PR TITLE
Use more generic pid for the non_existing case

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ fn invalid() {
 
 #[test]
 fn non_existing() {
-    WaitHandle::open(0xDEAD).expect_err("should not exist");
+    WaitHandle::open(0).expect_err("should not exist");
 }
 
 // Only Linux and Windows support opening zombie processes.


### PR DESCRIPTION
Although the actual range for PID is platform-specific, the corresponding integer type is i32 in most cases, which is exactly the parameter type of `WaitHandle::open`. The pid `57005` falls into this range, the test might fail in some cases. Or more specifically, we could just simulate that case by: 
```bash
echo 57004 >/proc/sys/kernel/ns_last_pid; sleep 1000;
```

Alternatively, pid 0 is the process used by the kernel before pid 1(init process), it is invisible from user space. Since the library mainly aims for the user space, we can make use of it to test against `non_exisitng` case.